### PR TITLE
Movesets are now loaded from a json data file

### DIFF
--- a/Assets/Scripts/ChessPiece.cs
+++ b/Assets/Scripts/ChessPiece.cs
@@ -62,12 +62,29 @@ public class ChessPiece : MonoBehaviour
 
     void Start()
     {
-        
+        SetRelativeMoveset();
     }
     
     void Update()
     {
         
+    }
+
+    // Sets the relative moveset
+    // If no parameters are provided, the moveset corresponding to the team and the chessPieceType is set
+    // Parameters can be provided for custom relative movesets, such as an upgraded piece that handles more movesets than usual
+    public void SetRelativeMoveset(bool customRelativeMoveset = false, string customRelativeMovesetType = "")
+    {
+        // TODO: Change this to match a RelativeMoveset service
+        RelativeMovesets relativeMovesetController = GameObject.Find("Temporary_RelativeMovesets").GetComponent<RelativeMovesets>();
+        if (customRelativeMoveset)
+        {
+            RelativeMoveset = relativeMovesetController.GetChessPieceMoveset(Team, customRelativeMovesetType);
+        }
+        else
+        {
+            RelativeMoveset = relativeMovesetController.GetChessPieceMoveset(Team, PieceType.ToString());
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/JSON.meta
+++ b/Assets/Scripts/JSON.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 90331fb6722db2543ab7afba5b03bc31
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/JSON/relative_movesets.json
+++ b/Assets/Scripts/JSON/relative_movesets.json
@@ -1,0 +1,52 @@
+{
+  "TeamBehaviors": [
+    {
+      "Behavior": 0,
+      "ChessPieces": [
+        {
+          "ChessPieceName": "Pawn",
+          "Movesets": [
+            { "x": 0, "y": 1 }
+          ]
+        },
+        {
+          "ChessPieceName": "Knight",
+          "Movesets": [
+            { "x":  -1, "y": 2},
+            { "x":  1, "y": 2},
+            { "x":  2, "y": 1},
+            { "x":  2, "y": -1},
+            { "x":  1, "y": -2},
+            { "x":  -1, "y": -2},
+            { "x":  -2, "y": -1},
+            { "x":  -2, "y": 1}
+          ]
+        }
+      ]
+    },
+    {
+      "Behavior": 1,
+      "ChessPieces": [
+        {
+          "ChessPieceName": "Pawn",
+          "Movesets": [
+            { "x": 0, "y": -1 }
+          ]
+        },
+        {
+          "ChessPieceName": "Knight",
+          "Movesets": [
+            { "x":  -1, "y": 2},
+            { "x":  1, "y": 2},
+            { "x":  2, "y": 1},
+            { "x":  2, "y": -1},
+            { "x":  1, "y": -2},
+            { "x":  -1, "y": -2},
+            { "x":  -2, "y": -1},
+            { "x":  -2, "y": 1}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Assets/Scripts/JSON/relative_movesets.json.meta
+++ b/Assets/Scripts/JSON/relative_movesets.json.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 714f69920c384ff6824749ae00c3a66d
+timeCreated: 1707688215

--- a/Assets/Scripts/RelativeMovesets.cs
+++ b/Assets/Scripts/RelativeMovesets.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+using System.Linq;
+using Services;
+
+public class RelativeMovesets : MonoBehaviour
+{ 
+  public MovesetData MovesetDataObject;
+    
+  // Class initialization
+  private void Start()
+  {
+      try
+      {
+          string relativeMovesetsString = File.ReadAllText(Application.dataPath +
+                                                           "/Scripts/JSON/relative_movesets.json");
+          SetupMovesetData(relativeMovesetsString);
+      }
+      catch (Exception ex)
+      {
+          Debug.Log("Movesets could not be generated. Exception: ${ex}");
+      }
+  }
+
+  // Reads JSON and serializes into MovesetData object
+  private void SetupMovesetData(string jsonString)
+  {
+      MovesetDataObject = JsonUtility.FromJson<MovesetData>(jsonString);
+  }
+  
+  // Gets an specific moveset
+  public List<Vector2> GetChessPieceMoveset(Team team, string pieceType)
+  {
+      TeamBehavior mTeamBehavior = MovesetDataObject.TeamBehaviors.Find((t) => t.Behavior == (int)team);
+      if (mTeamBehavior != null)
+      {
+          ChessPieceMovement pieceMovementData =
+              mTeamBehavior.ChessPieces.Find((movement) => movement.ChessPieceName == pieceType);
+          if (pieceMovementData != null)
+              return pieceMovementData.Movesets;
+      }
+      
+      Debug.Log("ChessPieceMovement could not be retrieved from the moveset data!");
+      return new List<Vector2>();
+  }
+}
+
+
+
+// -- Serializable classes for loading JSON onto a MovesetData object --
+[Serializable]
+public class MovesetData
+{
+    public List<TeamBehavior> TeamBehaviors;
+}
+
+[Serializable]
+public class TeamBehavior
+{
+    public int Behavior;
+    public List<ChessPieceMovement> ChessPieces;
+}
+
+[Serializable]
+public class ChessPieceMovement
+{
+    public string ChessPieceName;
+    public List<Vector2> Movesets;
+}

--- a/Assets/Scripts/RelativeMovesets.cs.meta
+++ b/Assets/Scripts/RelativeMovesets.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13c4d480abea74e4abd691cc35f6d74d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Changes

- Movesets are now saved in a JSON file and loaded into the chess pieces. This systems takes in consideration custom movesets (like for example an upgraded chess piece) and allows the same chess piece type to have different movesets if necessary.



The RelativeMoveset class should be upgraded to a service, I was not sure how to do it so maybe we can discuss it in the meeting.

I will add all the JSON movesets once this PR is merged in case any format change is needed.

Edit: Don't merge yet, some changes are needed