### PR TITLE
feat: Spawning system for enemy chess pieces

### DIFF
--- a/Assets/Scenes/TestBoardManager.unity
+++ b/Assets/Scenes/TestBoardManager.unity
@@ -167,6 +167,7 @@ Transform:
   - {fileID: 1771712755}
   - {fileID: 267976231}
   - {fileID: 1854989048}
+  - {fileID: 1253927024}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3228,6 +3229,49 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e14fcf069a8276b4499a61990178bb13, type: 3}
+--- !u!1 &1253927023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1253927024}
+  - component: {fileID: 1253927025}
+  m_Layer: 0
+  m_Name: EnemySpawnerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1253927024
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1253927023}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 72178215}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1253927025
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1253927023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5055811ed027b2044a58515d9f4249f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1263333908
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4566,6 +4610,66 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 631281325085060932, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 631281325085060932, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 631281325085060932, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 631281325085060932, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 631281325085060932, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 631281325085060932, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2578220930395653236, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2578220930395653236, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2578220930395653236, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2578220930395653236, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2578220930395653236, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2578220930395653236, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3132466352305515509, guid: be40eae696d6ec94494a9284d19172af,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -4646,6 +4750,21 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4759903728090662092, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759903728090662092, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759903728090662092, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5553590665916253491, guid: be40eae696d6ec94494a9284d19172af,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -4662,6 +4781,36 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5553590665916253491, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7452862696351950419, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7452862696351950419, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7452862696351950419, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7452862696351950419, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7452862696351950419, guid: be40eae696d6ec94494a9284d19172af,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7452862696351950419, guid: be40eae696d6ec94494a9284d19172af,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0

--- a/Assets/Scripts/Managers/BoardManager.cs
+++ b/Assets/Scripts/Managers/BoardManager.cs
@@ -260,6 +260,12 @@ public class BoardManager : MonoService
     {
         BoardSquare square = GetTile(pos);
 
+        if (!square.IsEmpty())
+        {
+            Debug.Log("Cannot create chess piece on given BoardSquare because there is already a chess piece assigned.");
+            return null;
+        }
+
         ChessPiece piece;
 
         //Instantiate given piece
@@ -302,6 +308,12 @@ public class BoardManager : MonoService
         return piece;
     }
 
+    // Returns the number of [rows, columns]
+    public int[] GetBoardDimensions()
+    {
+        return new int[] {_boardDepth, _boardWidth };
+    }
+    
     /// <summary>
     /// Create a chess piece at the specified location.
     /// </summary>

--- a/Assets/Scripts/Managers/EnemySpawner.cs
+++ b/Assets/Scripts/Managers/EnemySpawner.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Services;
+using Random = System.Random;
+
+public class EnemySpawner : MonoService
+{
+    // Services
+    private EasyService<GameStateManager> _gameStateManager;
+    private EasyService<BoardManager> _boardManager;
+    private IndexCode[][] _boardRows;
+    
+    // Settings
+    public int MaxTurnsWithoutSpawning = 4;
+    private int _lastTurnWithSpawns = 0;
+    
+    // Useful
+    Random random = new Random();
+    
+    void Start()
+    {
+        InitializeRowData();
+    }
+
+    public void ExecuteSpawning()
+    {
+        // Variables
+        int turnNumber = _gameStateManager.Value.GetTurnNumber();
+        // Are there going to be spawns this turn?
+        bool spawnThisTurn = GetSpawningBool(turnNumber);
+        
+        Debug.Log($"Executing Spawning. Turn number {turnNumber}");
+        
+        if (spawnThisTurn)
+        {
+            Array pieceValues = Enum.GetValues(typeof(ChessPieceType));
+            ChessPieceType randomPiece = (ChessPieceType)pieceValues.GetValue(random.Next(pieceValues.Length));
+            int rowForSpawning = random.Next(5, 7);
+            int columnForSpawning = random.Next(0, _boardManager.Value.GetBoardDimensions()[0]);
+            IndexCode position = _boardRows[rowForSpawning][columnForSpawning];
+
+            Debug.Log($"Spawning enemy chess piece of type {randomPiece}, on IndexCode {position}");
+            
+            // Create chess piece. If the board square is already occupied, loop until a valid board square is found.
+            ChessPiece piece = null;
+            int counter = 0;
+            while (piece == null)
+            {
+                counter++;
+                piece = SpawnEnemy(randomPiece, position);
+                
+                // Relocate chess piece position if it is not valid
+                rowForSpawning = random.Next(5, 7);
+                columnForSpawning = random.Next(0, _boardManager.Value.GetBoardDimensions()[0]);
+                position = _boardRows[rowForSpawning][columnForSpawning];
+                
+                // If all square boards are occupied, no spawning is done
+                // This prevents an infinite loop if all board squares have their pieces assigned
+                if (counter > 24)
+                {
+                    return;
+                }
+            }
+            
+            // Random upgrades
+            double rangeUpgradeChance = random.NextDouble();
+            double speedUpgradeChance = random.NextDouble();
+            // Only upgrade pieces after turn 10
+            if (turnNumber < 10)
+            {
+                // do nothing
+            }
+            else if (turnNumber < 25)
+            {
+                if (rangeUpgradeChance < 0.3)
+                    piece.Range++;
+                if (speedUpgradeChance < 0.5)
+                    piece.Speed++;
+            }
+            else if (turnNumber < 50)
+            {
+                if (rangeUpgradeChance < 0.6)
+                    piece.Range++;
+                if (speedUpgradeChance < 0.5)
+                    piece.Speed++;
+            }
+            else
+            {
+                // If turn is superior to 50, piece is upgraded by default
+                piece.Range++;
+                piece.Speed++;
+                
+                // Can be upgraded twice at this point
+                if (rangeUpgradeChance > 0.5)
+                    piece.Range++;
+                if (speedUpgradeChance < 0.5)
+                    piece.Speed++;
+            }
+        }
+
+        // Once spawning is finished, transition to preparation phase
+        _gameStateManager.Value.GameState = GameState.PREP;
+    }
+
+    // Generate an array of arrays with the position of the board squares
+    private void InitializeRowData()
+    {
+        int rowCount = _boardManager.Value.GetBoardDimensions()[0];
+        int columnCount = _boardManager.Value.GetBoardDimensions()[1];
+        _boardRows =  new IndexCode[rowCount][];
+        
+        for (int row = 0; row < rowCount; row++)
+        {
+            int skipCounter = 0;
+            IndexCode[] indexCodesPerRow = new IndexCode[columnCount];
+            for (int column = 0; column < columnCount; column++)
+            {
+                indexCodesPerRow[column] = (IndexCode)(skipCounter + row);
+                skipCounter += rowCount;
+            }
+
+            _boardRows[row] = indexCodesPerRow;
+        }
+        DebugRowIndexCodes();
+    }
+
+    
+    // Debugs the rows in boardRows array. Helps to visualize if the rows are correctly setup
+    private void DebugRowIndexCodes()
+    {
+        for (int i = 0; i < _boardManager.Value.GetBoardDimensions()[0]; i++)
+        {
+            string indexCodes = "";
+            foreach (int intCode in _boardRows[i])
+            {
+                indexCodes += $" {(IndexCode)intCode} ";
+            }
+            Debug.Log($"Row {i} has the following index codes: [{indexCodes}]");
+        }
+    }
+
+    // Returns how many enemy chess pieces will spawn this turn
+    private bool GetSpawningBool(int turnNumber)
+    {
+        bool SpawnByTurnExpiration =
+            _lastTurnWithSpawns + MaxTurnsWithoutSpawning < turnNumber;
+
+        // Spawning by expiration should be disabled on the first 5 turns
+        if (turnNumber < 5)
+        {
+            SpawnByTurnExpiration = false;
+        }
+        
+        bool SpawnByChance = random.NextDouble() * 100 < GetSpawnChance(turnNumber);
+
+        if (SpawnByTurnExpiration || SpawnByChance)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    // Returns the spawn chance based on the turn. A mathematical formula is used
+    // The spawn chance is higher, the higher the turn count is
+    private double GetSpawnChance(int turnNumber)
+    {
+        double exponent = 1.5 / (15.0 / (turnNumber + 14));
+        return 15.0f + Math.Pow(2.0, exponent);
+    }
+
+    private ChessPiece SpawnEnemy(ChessPieceType pieceType, IndexCode indexCode)
+    {
+        _lastTurnWithSpawns = _gameStateManager.Value.GetTurnNumber();
+        return _boardManager.Value.CreatePiece(pieceType, indexCode, Team.Enemy);
+    }
+}

--- a/Assets/Scripts/Managers/EnemySpawner.cs.meta
+++ b/Assets/Scripts/Managers/EnemySpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5055811ed027b2044a58515d9f4249f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/ExecutionOrderManager.cs
+++ b/Assets/Scripts/Managers/ExecutionOrderManager.cs
@@ -52,7 +52,7 @@ public class ExecutionOrderManager : MonoService
         else
         {
             OnCombatComplete?.Invoke();
-            _stateManager.Value.GameState = GameState.PREP;
+            _stateManager.Value.GameState = GameState.SPAWN;
         }
     }
 

--- a/Assets/Scripts/Managers/GameStateManager.cs
+++ b/Assets/Scripts/Managers/GameStateManager.cs
@@ -9,7 +9,10 @@ public class GameStateManager : MonoService
 
     private GameState _gameState;
     private float _stateChangeTime;
+    private int _turnCount;
     private EasyService<TransitionController> _transitionController;
+    private EasyService<ExecutionOrderManager> _executionOrderManager;
+    private EasyService<EnemySpawner> _enemySpawner;
 
 
 
@@ -44,6 +47,7 @@ public class GameStateManager : MonoService
                 case GameState.START:
                     break;
                 case GameState.SPAWN:
+                    _enemySpawner.Value.ExecuteSpawning();
                     break;
                 case GameState.PREP:
                     break;
@@ -67,6 +71,7 @@ public class GameStateManager : MonoService
     void Start()
     {
         GameState = GameState.PREP;
+        _executionOrderManager.Value.OnTimeLineInit += IncreaseTurnCount;
     }
 
     void Update()
@@ -78,7 +83,16 @@ public class GameStateManager : MonoService
     {
         return Time.time - _stateChangeTime;
     }
+    
+    public int GetTurnNumber()
+    {
+        return _turnCount;
+    }
 
+    private void IncreaseTurnCount()
+    {
+        _turnCount++;
+    }
 }
 
 


### PR DESCRIPTION
Changes
--

- Fixed a bug where chess pieces could be created on a board square that already had a chess piece.
- EnemySpawner created. Enemies are spawned **based on a chance that increments while turn count increases**.
- EnemySpawner also spawns chess pieces if there have been no spawns in a X number of turns.
- **Turn count is now registered** in the game state manager.
- Added a subscription to increase the turn count when _OnTimeLineInit_.