### PR TITLE
fix: OnEnable in statsUI is now correctly checking scoremanager init

### DIFF
--- a/Assets/Scripts/UI/StatsUI.cs
+++ b/Assets/Scripts/UI/StatsUI.cs
@@ -51,7 +51,7 @@ public class StatsUI : MonoBehaviour
 
     private void OnEnable()
     {
-        if (!_scoreManager.IsAssigned)
+        if (!_scoreManager.HasService())
         {
             return;
         }


### PR DESCRIPTION
Changes
--

- OnEnable in StatsUI is now correctly recognizing the initialization of ScoreManager service.