### PR TITLE
_pieces dictionary now correctly updated when moving pieces

### DIFF
--- a/Assets/Scripts/BoardSquare.cs
+++ b/Assets/Scripts/BoardSquare.cs
@@ -25,7 +25,8 @@ public class BoardSquare : MonoBehaviour
         set
         {
             _chessPieceAssigned = value;
-            _chessPieceAssigned.AssignedSquare = this;
+            if (value != null)
+                _chessPieceAssigned.AssignedSquare = this;
         }
     }
 

--- a/Assets/Scripts/ChessPiece.cs
+++ b/Assets/Scripts/ChessPiece.cs
@@ -127,6 +127,7 @@ public class ChessPiece : MonoBehaviour
     private EasyService<AudioManager> _audioManager;
     private EasyService<ScoreManager> _scoreManager;
     private EasyService<GameStateManager> _stateManager;
+    private EasyService<BoardManager> _boardManager;
 
     public int Range
     {
@@ -569,14 +570,16 @@ public class ChessPiece : MonoBehaviour
 
             State = ChessPieceState.ATTACK;
             dst.ChessPieceAssigned.State = ChessPieceState.DEAD;
-            MoveToBlock(dst);
+            //MoveToBlock(dst);
+            _boardManager.Value.MovePiece((AssignedSquare.IndexX, AssignedSquare.IndexZ), (dst.IndexX, dst.IndexZ));
         }
         else
         {
             if (GlobalDebug.Instance.ShowCombatMessageLogs)
                 Debug.Log($"\t\tMOVING to {dst.IndexCode}\n");
             State = ChessPieceState.MOVE;
-            MoveToBlock(dst);
+            //MoveToBlock(dst);
+            _boardManager.Value.MovePiece((AssignedSquare.IndexX, AssignedSquare.IndexZ), (dst.IndexX, dst.IndexZ));
         }
     }
 

--- a/Assets/Scripts/Managers/BoardManager.cs
+++ b/Assets/Scripts/Managers/BoardManager.cs
@@ -556,6 +556,10 @@ public class BoardManager : MonoService
             Destroy(capture.gameObject);
         }
 
+        // clear previous board square chess piece reference
+        var srcTile = GetTile(src);
+        srcTile.Clear();
+        
         // do the logical move
         _pieces.Remove(src);
         _pieces.Add(dst, piece);


### PR DESCRIPTION
Changes
--

- Fixed the bug that was breaking the game. It turns out that when the chess pieces moved, the dictionary of the positions was not updated. If I placed a Rook on (4,6) and then it was moved to (5,7), it was visually moved but not updated in the _pieces dictionary. So if a piece was moved, or a piece was spawned at (4,6), the game broke.