### PR TITLE
timeline: fix race condition on killing a piece

### DIFF
--- a/Assets/Scripts/Services.meta
+++ b/Assets/Scripts/Services.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: cdadf442987fa764dbd405b148e02273
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/UI/UnitOrderTimelineController.cs
+++ b/Assets/Scripts/UI/UnitOrderTimelineController.cs
@@ -217,10 +217,9 @@ public class UnitOrderTimelineController : MonoService
 
     private IEnumerator DelayedKill(TimelineNode nodeToRemove)
     {
+        _nodes.Remove(nodeToRemove);
         nodeToRemove.KillAnimation(1f);
         yield return new WaitForSeconds(1.2f);
-        bool s = _nodes.Remove(nodeToRemove);
         RefreshTimelinePositions();
-        
     }
 }

--- a/Assets/Test.meta
+++ b/Assets/Test.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: ba4e8a0b3fc1f1a4ea5c8cc9560a8cff
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
A TimelineNode's kill animation deletes the node itself after the animation concludes. However, the UnitOrderTimelineController keeps a reference to that around while waiting for it to conclude, creating a race condition that can result in crash.

The race condition is fixed by splicing the TimelineNode reference from UnitOrderTimelineController's piece list before the animation and the Unity coroutine wait. This way, all other references are actually dropped before the TimelineNode deletes itself, and the random crash will no longer happen.